### PR TITLE
initial additions for URL parsing

### DIFF
--- a/AutotypeURL/ATUAutotypeURL.m
+++ b/AutotypeURL/ATUAutotypeURL.m
@@ -8,6 +8,7 @@
 
 #import "ATUAutotypeURL.h"
 
+
 static NSString *ATUChromeBundleIdentifier = @"com.google.Chrome";
 static NSString *ATUSafariBundleIdentifier = @"com.apple.Safari";
 
@@ -51,8 +52,16 @@ static NSString *ATUSafariBundleIdentifier = @"com.apple.Safari";
 
 - (NSString *)_getURLFromSafari {
   NSAppleScript *script = [[NSAppleScript alloc] initWithSource:@"tell application \"Safari\" to get URL of front document"];
-  NSAppleEventDescriptor *aed = [script executeAndReturnError:NULL];
-  return aed.stringValue;
+    NSAppleEventDescriptor *aed = [script executeAndReturnError:NULL];
+    NSString *rawURL = aed.stringValue;
+  
+
+    NSLog(@"%@ - raw URL", rawURL);
+
+    NSLog(@"%@ - parsedURL", [self _parseURL:rawURL]);
+    return [self _parseURL:rawURL];
+    
+    
 }
 
 - (NSString *)_getURLFromChrome {
@@ -60,5 +69,16 @@ static NSString *ATUSafariBundleIdentifier = @"com.apple.Safari";
   NSAppleEventDescriptor *aed = [script executeAndReturnError:NULL];
   return aed.stringValue;
 }
+//Additions for parsing the url subdomain.root.com
+- (NSString *)_parseURL: (NSString*) url;
+{
+    NSArray *separatedURL = [url componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
+    NSString *subDomIncluded = separatedURL[2];
+    return subDomIncluded;
+    
+    
+    
+}
 
 @end
+

--- a/AutotypeURL/ATUAutotypeURL.m
+++ b/AutotypeURL/ATUAutotypeURL.m
@@ -54,8 +54,8 @@ static NSString *ATUSafariBundleIdentifier = @"com.apple.Safari";
     NSAppleEventDescriptor *aed = [script executeAndReturnError:NULL];
     NSString *rawURL = aed.stringValue;
     
-    NSLog(@"%@ - raw URL", rawURL);
-    NSLog(@"%@ - parsedURL", [self _parseURL:rawURL]);
+    NSLog(@"%@ - raw URL Safari", rawURL);
+    NSLog(@"%@ - parsedURL Safari", [self _parseURL:rawURL]);
     return [self _parseURL:rawURL];
     
     
@@ -64,7 +64,11 @@ static NSString *ATUSafariBundleIdentifier = @"com.apple.Safari";
 - (NSString *)_getURLFromChrome {
     NSAppleScript *script = [[NSAppleScript alloc] initWithSource:@"tell application \"Google Chrome\" to get URL of active tab of front window"];
     NSAppleEventDescriptor *aed = [script executeAndReturnError:NULL];
-    return aed.stringValue;
+    NSString *rawURL = aed.stringValue;
+  
+    NSLog(@"%@ - raw URL Chrome", rawURL);
+    NSLog(@"%@ - parsedURL Chrome", [self _parseURL:rawURL]);
+    return [self _parseURL:rawURL];
 }
 //Additions for parsing the url subdomain.root.com
 - (NSString *)_parseURL: (NSString*) url {

--- a/AutotypeURL/ATUAutotypeURL.m
+++ b/AutotypeURL/ATUAutotypeURL.m
@@ -8,7 +8,6 @@
 
 #import "ATUAutotypeURL.h"
 
-
 static NSString *ATUChromeBundleIdentifier = @"com.google.Chrome";
 static NSString *ATUSafariBundleIdentifier = @"com.apple.Safari";
 
@@ -22,11 +21,11 @@ static NSString *ATUSafariBundleIdentifier = @"com.apple.Safari";
 @implementation NSRunningApplication (ATUAutotypeURLAdditions)
 
 - (BOOL)atu_isSafari {
-  return [self.bundleIdentifier isEqualToString:ATUSafariBundleIdentifier];
+    return [self.bundleIdentifier isEqualToString:ATUSafariBundleIdentifier];
 }
 
 - (BOOL)atu_isChrome {
-  return [self.bundleIdentifier isEqualToString:ATUChromeBundleIdentifier];
+    return [self.bundleIdentifier isEqualToString:ATUChromeBundleIdentifier];
 }
 
 @end
@@ -34,30 +33,28 @@ static NSString *ATUSafariBundleIdentifier = @"com.apple.Safari";
 @implementation ATUAutotypeURL
 
 - (BOOL)acceptsRunningApplication:(nonnull NSRunningApplication *)runningApplication {
-  if(runningApplication.atu_isChrome || runningApplication.atu_isSafari) {
-    return YES;
-  }
-  return NO;
+    if(runningApplication.atu_isChrome || runningApplication.atu_isSafari) {
+        return YES;
+    }
+    return NO;
 }
 
 - (nonnull NSString *)windowTitleForRunningApplication:(nonnull NSRunningApplication *)runningApplication {
-  if(runningApplication.atu_isSafari) {
-    return [self _getURLFromSafari];
-  }
-  if(runningApplication.atu_isChrome) {
-    return [self _getURLFromChrome];
-  }
-  return @"";
+    if(runningApplication.atu_isSafari) {
+        return [self _getURLFromSafari];
+    }
+    if(runningApplication.atu_isChrome) {
+        return [self _getURLFromChrome];
+    }
+    return @"";
 }
 
 - (NSString *)_getURLFromSafari {
-  NSAppleScript *script = [[NSAppleScript alloc] initWithSource:@"tell application \"Safari\" to get URL of front document"];
+    NSAppleScript *script = [[NSAppleScript alloc] initWithSource:@"tell application \"Safari\" to get URL of front document"];
     NSAppleEventDescriptor *aed = [script executeAndReturnError:NULL];
     NSString *rawURL = aed.stringValue;
-  
-
+    
     NSLog(@"%@ - raw URL", rawURL);
-
     NSLog(@"%@ - parsedURL", [self _parseURL:rawURL]);
     return [self _parseURL:rawURL];
     
@@ -65,18 +62,15 @@ static NSString *ATUSafariBundleIdentifier = @"com.apple.Safari";
 }
 
 - (NSString *)_getURLFromChrome {
-  NSAppleScript *script = [[NSAppleScript alloc] initWithSource:@"tell application \"Google Chrome\" to get URL of active tab of front window"];
-  NSAppleEventDescriptor *aed = [script executeAndReturnError:NULL];
-  return aed.stringValue;
+    NSAppleScript *script = [[NSAppleScript alloc] initWithSource:@"tell application \"Google Chrome\" to get URL of active tab of front window"];
+    NSAppleEventDescriptor *aed = [script executeAndReturnError:NULL];
+    return aed.stringValue;
 }
 //Additions for parsing the url subdomain.root.com
-- (NSString *)_parseURL: (NSString*) url;
-{
-    NSArray *separatedURL = [url componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
-    NSString *subDomIncluded = separatedURL[2];
+- (NSString *)_parseURL: (NSString*) url {
+    NSURL *separatedURL = [[NSURL alloc] initWithString:url];
+    NSString *subDomIncluded = [separatedURL host];
     return subDomIncluded;
-    
-    
     
 }
 


### PR DESCRIPTION
Can't fully test getting "Unsupported plugin error". I tried doing fresh pull and compile of MacPass, but no change. Plugin builds successfully. 

However, force loading incompatible plugins shows in the NSLog the right value is being captured and sent.
Example: https://subdom.root.com/this/page.html
Returned value: subdom.root.com

Left the NSLog info in and only applied to Safari. I didn't have Chrome installed to test.